### PR TITLE
Allows pointer for boxSize parameter in Sparx

### DIFF
--- a/eman2/protocols/protocol_autopick_sparx.py
+++ b/eman2/protocols/protocol_autopick_sparx.py
@@ -50,7 +50,7 @@ class SparxGaussianProtPicking(ProtParticlePickingAuto):
     # --------------------------- DEFINE param functions ----------------------
     def _defineParams(self, form):
         ProtParticlePickingAuto._defineParams(self, form)
-        form.addParam('boxSize', IntParam, default=100,
+        form.addParam('boxSize', IntParam, default=100, allowsPointers=True,
                       label='Box Size', help='Box size in pixels')
         line = form.addLine('Picker range',
                             help='CCF threshold range for automatic picking')

--- a/eman2/wizards.py
+++ b/eman2/wizards.py
@@ -50,6 +50,11 @@ class SparxGaussianPickerWizard(EmWizard):
         if not micSet:
             print('must specify input micrographs')
             return
+
+        # ensuring a valid boxSize
+        if autopickProt.boxSize.get() is None:
+            autopickProt.boxSize.set(100)
+
         project = autopickProt.getProject()
         coordsDir = project.getTmpPath(micSet.getName())
 


### PR DESCRIPTION
Setting `allowsPointers=True` in 'boxSize' param of the Sparx protocol.

Also, adding a test to check that this feature it's working fine.

Additionally, I've changed the 'raise' for a simple print for the new AutoPick test when v2.21 is not detected. That's to be able to continue with the other tests.
If you prefer to get a failure in the test when v2.21 is not active, we can change the whole conditional to
```
self.assertTrue(eman2.Plugin.isNewVersion(), 'This protocol exists only for EMAN2.21 or higher!')
``` 
but I personally think that the test shouldn't fail in this case, but as you prefer. 