### PR TITLE
Feature/extract params2

### DIFF
--- a/eman2/protocols/protocol_tomo_extraction.py
+++ b/eman2/protocols/protocol_tomo_extraction.py
@@ -179,8 +179,11 @@ class EmanProtTomoExtraction(pwem.EMProtocol, ProtTomoBase):
 
     # --------------------------- STEPS functions -----------------------------
     def extractParticles(self):
-        TsCoord = self.inputCoordinates.get().getSamplingRate()
         TsTomo = self.getInputTomogram().getSamplingRate()
+        if self.inputCoordinates.get().getSamplingRate() is not None:
+            TsCoord = self.inputCoordinates.get().getSamplingRate()
+        else:
+            TsCoord = TsTomo
         self.cshrink = float(TsCoord/(TsTomo*self.downFactor.get()))
         fnTomo = self.getInputTomogram().getFileName()
         args = '%s --coords %s --boxsize %d' % (fnTomo, pwutils.replaceBaseExt(self.getInputTomogram().getFileName(), 'coords'),

--- a/eman2/protocols/protocol_tomo_extraction.py
+++ b/eman2/protocols/protocol_tomo_extraction.py
@@ -32,8 +32,6 @@ from tomo.objects import SetOfSubTomograms, SubTomogram
 import eman2
 from eman2.constants import *
 
-import xmippLib
-
 # Tomogram type constants for particle extraction
 SAME_AS_PICKING = 0
 OTHER = 1
@@ -88,7 +86,7 @@ class EmanProtTomoExtraction(pwem.EMProtocol, ProtTomoBase):
 
         form.addParam('downFactor', params.FloatParam, default=1.0,
                       label='Downsampling factor',
-                      help='Select a value greater than 1.0 to reduce the size '
+                      help='Select a value lower than 1.0 to reduce the size '
                            'of subtomograms after extraction. '
                            'If 1.0 is used, no downsample is applied. '
                            'Non-integer downsample factors are possible. ')
@@ -145,11 +143,8 @@ class EmanProtTomoExtraction(pwem.EMProtocol, ProtTomoBase):
             subtomogram.cleanObjId()
             subtomogram.setLocation(index, workDir)
             if self.downFactor.get() != 1:
-                I = xmippLib.Image(subtomogram.getLocation())
-                x, y, z, _ = I.getDimensions()
-                I.scale(int(x / self.downFactor.get()), int(y / self.downFactor.get()), int(z / self.downFactor.get()))
                 fnSubtomo = self._getExtraPath("downsampled_subtomo%d.mrc" % index)
-                I.write(fnSubtomo)
+                pwem.ImageHandler.scaleSplines(subtomogram.getLocation(),fnSubtomo,self.downFactor.get())
                 subtomogram.setLocation(fnSubtomo)
             subtomogram.setCoordinate3D(self.coordDict[index-1])
             subtomogram.setAcquisition(self.getInputTomogram().getAcquisition())

--- a/eman2/protocols/protocol_tomo_extraction.py
+++ b/eman2/protocols/protocol_tomo_extraction.py
@@ -179,12 +179,14 @@ class EmanProtTomoExtraction(pwem.EMProtocol, ProtTomoBase):
 
     # --------------------------- STEPS functions -----------------------------
     def extractParticles(self):
-        TsTomo = self.getInputTomogram().getSamplingRate()
+        # Compute cshrink parameter to have tomogram and coordinates at same sampling rate
+        # If coordinates do not have sampling rate, protocol assumes tomogram sampling rate
+        samplingRateTomo = self.getInputTomogram().getSamplingRate()
         if self.inputCoordinates.get().getSamplingRate() is not None:
-            TsCoord = self.inputCoordinates.get().getSamplingRate()
+            samplingRateCoord = self.inputCoordinates.get().getSamplingRate()
         else:
-            TsCoord = TsTomo
-        self.cshrink = float(TsCoord/(TsTomo*self.downFactor.get()))
+            samplingRateCoord = samplingRateTomo
+        self.cshrink = float(samplingRateCoord/(samplingRateTomo*self.downFactor.get()))
         fnTomo = self.getInputTomogram().getFileName()
         args = '%s --coords %s --boxsize %d' % (fnTomo, pwutils.replaceBaseExt(self.getInputTomogram().getFileName(), 'coords'),
             self.boxSize.get())

--- a/eman2/tests/test_protocols_eman.py
+++ b/eman2/tests/test_protocols_eman.py
@@ -410,8 +410,8 @@ class TestEmanAutopick(TestEmanBase):
 
 
 class TestEmanTomoExtraction(TestEmanBase):
-    """This class check if the protocol to extract particles
-    in Relion works properly.
+    """This class check if the protocol to extract subtomograms
+    in Eman works properly.
     """
 
     @classmethod
@@ -422,7 +422,7 @@ class TestEmanTomoExtraction(TestEmanBase):
         cls.tomogram = cls.dataset.getFile('tomo1')
         cls.coords3D = cls.dataset.getFile('eman_coordinates')
 
-    def _runTomoExtraction(self, downsampleType = 0, doInvert = False, doNormalize = False, cshrink = 1):
+    def _runTomoExtraction(self, downsampleType = 0, doInvert = False, doNormalize = False, boxSize = 32, downFactor = 1):
         from tomo.protocols import ProtImportCoordinates3D, ProtImportTomograms
         protImportTomogram = self.newProtocol(ProtImportTomograms,
                                  filesPath=self.tomogram,
@@ -450,14 +450,16 @@ class TestEmanTomoExtraction(TestEmanBase):
                                               downsampleType=downsampleType,
                                               doInvert=doInvert,
                                               doNormalize=doNormalize,
-                                              cshrink=cshrink)
+                                              boxSize=boxSize,
+                                              downFactor=downFactor)
         else:
             protTomoExtraction = self.newProtocol(EmanProtTomoExtraction,
                                               inputCoordinates=protImportCoordinates3d.outputCoordinates,
                                               downsampleType=downsampleType,
                                               doInvert=doInvert,
                                               doNormalize=doNormalize,
-                                              cshrink=cshrink)
+                                              boxSize=boxSize,
+                                              downFactor=downFactor)
         self.launchProtocol(protTomoExtraction)
         self.assertIsNotNone(protTomoExtraction.outputSetOfSubtomogram,
                              "There was a problem with SetOfSubtomogram output")
@@ -469,7 +471,6 @@ class TestEmanTomoExtraction(TestEmanBase):
         self.assertTrue(output)
         self.assertTrue(output.hasCoordinates3D())
         self.assertTrue(output.getCoordinates3D().getObjValue())
-
         return protTomoExtraction
 
     def test_extractParticlesWithDownSample(self):
@@ -478,7 +479,6 @@ class TestEmanTomoExtraction(TestEmanBase):
         self.assertTrue(output)
         self.assertTrue(output.hasCoordinates3D())
         self.assertTrue(output.getCoordinates3D().getObjValue())
-
         return protTomoExtraction
 
     def test_extractParticlesWithDoInvert(self):
@@ -487,7 +487,6 @@ class TestEmanTomoExtraction(TestEmanBase):
         self.assertTrue(output)
         self.assertTrue(output.hasCoordinates3D())
         self.assertTrue(output.getCoordinates3D().getObjValue())
-
         return protTomoExtraction
 
     def test_extractParticlesWithDoNormalize(self):
@@ -496,20 +495,26 @@ class TestEmanTomoExtraction(TestEmanBase):
         self.assertTrue(output)
         self.assertTrue(output.hasCoordinates3D())
         self.assertTrue(output.getCoordinates3D().getObjValue())
-
         return protTomoExtraction
 
-    def test_extractParticlesModifiedCshrink(self):
-        protTomoExtraction = self._runTomoExtraction(cshrink = 2)
+    def test_extractParticlesModifiedDownFactor(self):
+        protTomoExtraction = self._runTomoExtraction(downFactor = 2)
         output = getattr(protTomoExtraction, 'outputSetOfSubtomogram', None)
         self.assertTrue(output)
         self.assertTrue(output.hasCoordinates3D())
         self.assertTrue(output.getCoordinates3D().getObjValue())
+        return protTomoExtraction
 
+    def test_extractParticlesModifiedBoxSize(self):
+        protTomoExtraction = self._runTomoExtraction(boxSize = 64)
+        output = getattr(protTomoExtraction, 'outputSetOfSubtomogram', None)
+        self.assertTrue(output)
+        self.assertTrue(output.hasCoordinates3D())
+        self.assertTrue(output.getCoordinates3D().getObjValue())
         return protTomoExtraction
 
     def test_extractParticlesWithAllOptions(self):
-        protTomoExtraction = self._runTomoExtraction(cshrink = 2, doNormalize=True, doInvert=True)
+        protTomoExtraction = self._runTomoExtraction(boxSize = 64, downFactor = 2, doNormalize=True, doInvert=True)
         output = getattr(protTomoExtraction, 'outputSetOfSubtomogram', None)
         self.assertTrue(output)
         self.assertTrue(output.hasCoordinates3D())

--- a/eman2/wizards.py
+++ b/eman2/wizards.py
@@ -126,9 +126,14 @@ class EmanTomoExtractionWizard(EmWizard):
 
     def show(self, form):
         tomoExtractProt = form.protocol
-        boxSize = tomoExtractProt.inputCoordinates.get().getBoxSize()
+        inputCoordinates = tomoExtractProt.inputCoordinates.get()
+        if not inputCoordinates:
+            print('You must specify input coordinates')
+            return
+
+        boxSize = inputCoordinates.getBoxSize()
         if not boxSize:
-            tomoExtractProt.showInfo('These coordinates do not have box size. Please, enter box size manually.')
+            print('These coordinates do not have box size. Please, enter box size manually.')
             return
 
         if tomoExtractProt.downFactor.get() != 1:

--- a/eman2/wizards.py
+++ b/eman2/wizards.py
@@ -33,7 +33,8 @@ from pyworkflow.utils import makePath, cleanPath, readProperties
 
 import eman2
 from eman2.convert import writeSetOfMicrographs
-from eman2.protocols import SparxGaussianProtPicking
+from eman2.protocols import SparxGaussianProtPicking, EmanProtTomoExtraction
+
 
 # =============================================================================
 # PICKER
@@ -118,3 +119,19 @@ class SparxGaussianPickerWizard(EmWizard):
         if myprops['applyChanges'] == 'true':
             for param in params:
                 form.setVar(param, myprops[param + '.value'])
+
+
+class EmanTomoExtractionWizard(EmWizard):
+    _targets = [(EmanProtTomoExtraction, ['boxSize'])]
+
+    def show(self, form):
+        tomoextractProt = form.protocol
+        boxSize = tomoextractProt.inputCoordinates.get().getBoxSize()
+        if not boxSize:
+            tomoextractProt.showInfo('These coordinates do not have box size. Please, enter box size manually.')
+            return
+
+        if tomoextractProt.downFactor.get() != 1:
+            boxSize = float(boxSize/tomoextractProt.downFactor.get())
+
+        form.setVar('boxSize', boxSize)

--- a/eman2/wizards.py
+++ b/eman2/wizards.py
@@ -125,13 +125,13 @@ class EmanTomoExtractionWizard(EmWizard):
     _targets = [(EmanProtTomoExtraction, ['boxSize'])]
 
     def show(self, form):
-        tomoextractProt = form.protocol
-        boxSize = tomoextractProt.inputCoordinates.get().getBoxSize()
+        tomoExtractProt = form.protocol
+        boxSize = tomoExtractProt.inputCoordinates.get().getBoxSize()
         if not boxSize:
-            tomoextractProt.showInfo('These coordinates do not have box size. Please, enter box size manually.')
+            tomoExtractProt.showInfo('These coordinates do not have box size. Please, enter box size manually.')
             return
 
-        if tomoextractProt.downFactor.get() != 1:
-            boxSize = float(boxSize/tomoextractProt.downFactor.get())
+        if tomoExtractProt.downFactor.get() != 1:
+            boxSize = float(boxSize/tomoExtractProt.downFactor.get())
 
         form.setVar('boxSize', boxSize)


### PR DESCRIPTION
New parameters added to **protocol_tomo_extraction**:

-`Box size` can be now introduced by the user. There is also a wizard (`EmanTomoExtractionWizard`) that selects automatically the same box size as picking.
-`Downsampling factor`: a factor chosen by the user to downsample the subtomograms after the extraction.
-The parameter `factor` (_cshrink_) is no longer introduced by the user, instead, it is computed automatically from the sampling rate of input data.

-Change _micrographs_ by _tomograms_ in comments, summary and methods.

For the correct working of `protocol_tomo_extraction` it is necessary to have the changes in the PR scipion-em/scipion-em-tomo/pull/18 of `scipion-em-tomo` repository