### PR TITLE
Import coordinates in tomo_boxing 

### DIFF
--- a/eman2/protocols/protocol_tomo_boxing.py
+++ b/eman2/protocols/protocol_tomo_boxing.py
@@ -24,6 +24,8 @@
 # *
 # **************************************************************************
 
+import os
+
 from pyworkflow.utils.properties import Message
 from pyworkflow.gui.dialog import askYesNo
 from pyworkflow.protocol.params import BooleanParam, PointerParam, LEVEL_ADVANCED
@@ -119,12 +121,24 @@ class EmanProtTomoBoxing(ProtTomoPicking):
             coord3DSet.setObjComment(self.getSummary(coord3DSet))
             self._updateOutputSet(coord3DMap[index], coord3DSet, state=coord3DSet.STREAM_CLOSED)
 
-
     # --------------------------- STEPS functions -----------------------------
+    def _createInputCoordsFile(self):
+        cwd = os.getcwd()
+        infoDir = pwutils.join(cwd, 'info')
+        self._leaveWorkingDir()
+        fnInputCoor = 'extra-%s_info.json' % pwutils.removeBaseExt(self.inputTomo.getFileName())
+        pathInputCoor = pwutils.join(infoDir, fnInputCoor)
+        if not os.path.exists(pathInputCoor):
+            pwutils.makePath(infoDir)
+        return pathInputCoor
+
     def launchBoxingGUIStep(self, tomo):
         inputCoor = self.inputCoordinates.get()
         if inputCoor is not None:
-            coordinates2json(self, inputCoor)
+            pathInputCoor = self._createInputCoordsFile()
+            coordinates2json(pathInputCoor, inputCoor)
+            self._enterWorkingDir()
+
         program = eman2.Plugin.getProgram("e2spt_boxer.py")
         arguments = "%(inputTomogram)s"
         if self.inMemory:
@@ -190,4 +204,3 @@ class EmanProtTomoBoxing(ProtTomoPicking):
         else:
             summary.append(Message.TEXT_NO_OUTPUT_CO)
         return summary
-

--- a/eman2/protocols/protocol_tomo_boxing.py
+++ b/eman2/protocols/protocol_tomo_boxing.py
@@ -137,7 +137,9 @@ class EmanProtTomoBoxing(ProtTomoPicking):
             initFile = '{\n"boxes_3d": [\n\n],\n"class_list": {\n"0": {\n"boxsize": 32,\n"name": "particles_00"\n}\n}\n}'
             f.write(initFile)
             f.close()
-            linCoor = '[%d, %d, %d, "manual", 0.0, 0]' % (0, 0, 0) # Change 0s by first coor
+            linCoor = '[%d, %d, %d, "manual", 0.0, 0]' % (inputCoor.getFirstItem().getX(),
+                                                          inputCoor.getFirstItem().getY(),
+                                                          inputCoor.getFirstItem().getZ())
             r = open(pathInputCoor, "r")
             contents = r.readlines()
             r.close()
@@ -147,11 +149,11 @@ class EmanProtTomoBoxing(ProtTomoPicking):
             w.write(contents)
             w.close()
             for coor in inputCoor.iterCoordinates():
-                linCoor = '[%d, %d, %d, "manual", 0.0, 0],\n' % (coor.getX(), coor.getY(), coor.getZ()) # coor.getXYZ()
+                linCoor = '[%d, %d, %d, "manual", 0.0, 0],\n' % (coor.getX(), coor.getY(), coor.getZ())
                 r = open(pathInputCoor, "r")
-                contents = r.readlines()
+                contents = r.readlines()[1:]
                 r.close()
-                contents.insert(2, linCoor)
+                contents.insert(2, linCoor) # Do not read first line (already read above) # change to 3
                 w = open(pathInputCoor, "w")
                 contents = "".join(contents)
                 w.write(contents)

--- a/eman2/protocols/protocol_tomo_boxing.py
+++ b/eman2/protocols/protocol_tomo_boxing.py
@@ -88,6 +88,45 @@ class EmanProtTomoBoxing(ProtTomoPicking):
 
                 self._readCoordinates3D(box, tomo, coord3DSet)
 
+    def _coordinates2json(self, inputCoor):
+        cwd = os.getcwd()
+        infoDir = pwutils.join(cwd, 'info')
+        self._leaveWorkingDir()
+        fnInputCoor = 'extra-%s_info.json' % pwutils.removeBaseExt(self.inputTomo.getFileName())
+        pathInputCoor = pwutils.join(infoDir, fnInputCoor)
+        if not exists(pathInputCoor):
+            pwutils.makePath(infoDir)
+        f = open(pathInputCoor, 'w')
+        initFile = '{\n"boxes_3d": [\n\n],\n"class_list": {\n"0": {\n"boxsize": 32,\n"name": "particles_00"\n}\n}\n}'
+        f.write(initFile)
+        f.close()
+        firstItem = inputCoor.getFirstItem()
+        linCoor = '[%d, %d, %d, "manual", 0.0, 0]' % (firstItem.getX(), firstItem.getY(), firstItem.getZ())
+        r = open(pathInputCoor, "r")
+        contents = r.readlines()
+        r.close()
+        contents.insert(2, linCoor)
+        w = open(pathInputCoor, "w")
+        contents = "".join(contents)
+        w.write(contents)
+        w.close()
+        idx = 1
+        for coor in inputCoor.iterCoordinates():
+            if idx == 1:
+                idx += 1
+                continue
+            else:
+                linCoor = '[%d, %d, %d, "manual", 0.0, 0],\n' % (coor.getX(), coor.getY(), coor.getZ())
+                r = open(pathInputCoor, "r")
+                contents = r.readlines()
+                r.close()
+                contents.insert(2, linCoor)
+                w = open(pathInputCoor, "w")
+                contents = "".join(contents)
+                w.write(contents)
+                w.close()
+        self._enterWorkingDir()
+
     def _createOutput(self, outputDir):
         jsonFnbase = pwutils.join(outputDir, 'info',
                                   'extra-%s_info.json'
@@ -138,45 +177,6 @@ class EmanProtTomoBoxing(ProtTomoPicking):
         if askYesNo(Message.TITLE_SAVE_OUTPUT, Message.LABEL_SAVE_OUTPUT, None):
             self._leaveDir()  # going back to project dir
             self._createOutput(self.getWorkingDir())
-
-    def _coordinates2json(self, inputCoor):
-        cwd = os.getcwd()
-        infoDir = pwutils.join(cwd, 'info')
-        self._leaveWorkingDir()
-        fnInputCoor = 'extra-%s_info.json' % pwutils.removeBaseExt(self.inputTomo.getFileName())
-        pathInputCoor = pwutils.join(infoDir, fnInputCoor)
-        if not exists(pathInputCoor):
-            pwutils.makePath(infoDir)
-        f = open(pathInputCoor, 'w')
-        initFile = '{\n"boxes_3d": [\n\n],\n"class_list": {\n"0": {\n"boxsize": 32,\n"name": "particles_00"\n}\n}\n}'
-        f.write(initFile)
-        f.close()
-        firstItem = inputCoor.getFirstItem()
-        linCoor = '[%d, %d, %d, "manual", 0.0, 0]' % (firstItem.getX(), firstItem.getY(), firstItem.getZ())
-        r = open(pathInputCoor, "r")
-        contents = r.readlines()
-        r.close()
-        contents.insert(2, linCoor)
-        w = open(pathInputCoor, "w")
-        contents = "".join(contents)
-        w.write(contents)
-        w.close()
-        idx = 1
-        for coor in inputCoor.iterCoordinates():
-            if idx == 1:
-                idx += 1
-                continue
-            else:
-                linCoor = '[%d, %d, %d, "manual", 0.0, 0],\n' % (coor.getX(), coor.getY(), coor.getZ())
-                r = open(pathInputCoor, "r")
-                contents = r.readlines()
-                r.close()
-                contents.insert(2, linCoor)
-                w = open(pathInputCoor, "w")
-                contents = "".join(contents)
-                w.write(contents)
-                w.close()
-        self._enterWorkingDir()
 
     def _validate(self):
         errors = []

--- a/eman2/protocols/protocol_tomo_extraction.py
+++ b/eman2/protocols/protocol_tomo_extraction.py
@@ -164,7 +164,6 @@ class EmanProtTomoExtraction(pwem.EMProtocol, ProtTomoBase):
         self._defineOutputs(outputSetOfSubtomogram=self.outputSubTomogramsSet)
         self._defineSourceRelation(self.inputCoordinates, self.outputSubTomogramsSet)
 
-
     def writeSetOfCoordinates3D(self):
         self.coordsFileName = self._getExtraPath(
             pwutils.replaceBaseExt(self.getInputTomogram().getFileName(), 'coords'))
@@ -177,8 +176,11 @@ class EmanProtTomoExtraction(pwem.EMProtocol, ProtTomoBase):
 
     # --------------------------- STEPS functions -----------------------------
     def extractParticles(self):
-        TsCoord =self.inputCoordinates.get().getSamplingRate()
         TsTomo = self.inputTomogram.get().getSamplingRate()
+        if self.inputCoordinates.get().getSamplingRate() is not None:
+            TsCoord = self.inputCoordinates.get().getSamplingRate()
+        else:
+            TsCoord = TsTomo
         self.cshrink = float(TsCoord/(TsTomo*self.downFactor.get()))
         self.boxSize = self.boxSize.get()
         fnTomo = self.getInputTomogram().getFileName()

--- a/eman2/protocols/protocol_tomo_extraction.py
+++ b/eman2/protocols/protocol_tomo_extraction.py
@@ -166,9 +166,6 @@ class EmanProtTomoExtraction(pwem.EMProtocol, ProtTomoBase):
 
 
     def writeSetOfCoordinates3D(self):
-
-        # print('--------------------',self.inputCoordinates.get().getVolumes().get())
-
         self.coordsFileName = self._getExtraPath(
             pwutils.replaceBaseExt(self.getInputTomogram().getFileName(), 'coords'))
         self.coordDict = []

--- a/eman2/protocols/protocol_tomo_extraction.py
+++ b/eman2/protocols/protocol_tomo_extraction.py
@@ -176,12 +176,14 @@ class EmanProtTomoExtraction(pwem.EMProtocol, ProtTomoBase):
 
     # --------------------------- STEPS functions -----------------------------
     def extractParticles(self):
-        TsTomo = self.inputTomogram.get().getSamplingRate()
+        # Compute cshrink parameter of eman to have tomogram and coordinates at same sampling rate
+        # If coordinates do not have sampling rate the protocol assumes the same sampling rate as tomogram
+        samplingRateTomo = self.inputTomogram.get().getSamplingRate()
         if self.inputCoordinates.get().getSamplingRate() is not None:
-            TsCoord = self.inputCoordinates.get().getSamplingRate()
+            sampligRateCoord = self.inputCoordinates.get().getSamplingRate()
         else:
-            TsCoord = TsTomo
-        self.cshrink = float(TsCoord/(TsTomo*self.downFactor.get()))
+            sampligRateCoord = samplingRateTomo
+        self.cshrink = float(sampligRateCoord/(samplingRateTomo*self.downFactor.get()))
         self.boxSize = self.boxSize.get()
         fnTomo = self.getInputTomogram().getFileName()
         if self.downFactor.get() != 1:

--- a/eman2/wizards.py
+++ b/eman2/wizards.py
@@ -125,13 +125,13 @@ class EmanTomoExtractionWizard(EmWizard):
     _targets = [(EmanProtTomoExtraction, ['boxSize'])]
 
     def show(self, form):
-        tomoextractProt = form.protocol
-        boxSize = tomoextractProt.inputCoordinates.get().getBoxSize()
+        tomoExtractProt = form.protocol
+        boxSize = tomoExtractProt.inputCoordinates.get().getBoxSize()
         if not boxSize:
-            tomoextractProt.showInfo('These coordinates do not have box size. Please, enter box size manually.')
+            tomoExtractProt.showInfo('These coordinates do not have box size. Please, enter box size manually.')
             return
 
-        if tomoextractProt.downFactor.get() != 1:
-            boxSize = float(boxSize/tomoextractProt.downFactor.get())
+        if tomoExtractProt.downFactor.get() != 1:
+            boxSize = float(boxSize/tomoExtractProt.downFactor.get())
 
         form.setVar('boxSize', boxSize)


### PR DESCRIPTION
Protocol `tomo_boxing` is now able to **open a set of coordinates3D**. This allow the user to visualize and modify (remove and add) an imported set of coordinates3D. A new method (`_coordinates2json`) has been implemented to **transform the set of coordinates to a json file** able to be read by `tomo_boxing` protocol.
