### PR TITLE
Fix/initial model summary references

### DIFF
--- a/eman2/protocols/tomo_protocols/protocol_tomo_initialmodel.py
+++ b/eman2/protocols/tomo_protocols/protocol_tomo_initialmodel.py
@@ -145,7 +145,7 @@ class EmanProtTomoInitialModel(EMProtocol, ProtTomoBase):
             'numberOfBatches': self.numberOfBatches.get(),
             'mask': self.mask.get(),
             'shrink': self.shrink.get(),
-            'reference': self.reference.get().getFileName(),
+            'reference': self.reference.get().getFileName() if self.reference.get() else None,
             'outputPath': self.getOutputPath(),
          }
         args = '%s/*.hdf' % self._getExtraPath("particles")

--- a/eman2/protocols/tomo_protocols/protocol_tomo_initialmodel.py
+++ b/eman2/protocols/tomo_protocols/protocol_tomo_initialmodel.py
@@ -208,8 +208,10 @@ class EmanProtTomoInitialModel(EMProtocol, ProtTomoBase):
 
     def _summary(self):
         particles = self.particles.get()
-
-        return filter(bool, [
+        reference = self.reference.get()
+        lines = [
             "Particles: %d" % particles.getSize(),
-            self.reference and "Reference file used: %s" % self.reference.get().getFileName(),
-        ])
+            "Reference file used: %s" % reference.getFileName() if reference else None,
+        ]
+
+        return list(filter(bool, lines))

--- a/eman2/tests/test_protocols_eman.py
+++ b/eman2/tests/test_protocols_eman.py
@@ -620,6 +620,12 @@ class TestEmanTomoInitialModel(TestEmanTomoBase):
             matrix = subTomogram.getTransform().getMatrix()
             self.assertEqual(matrix.shape, (4, 4))
 
+        summary = protInitialModel.summary()
+        self.assertIsNotNone(summary)
+        self.assertEqual(len(summary), 2)
+        self.assertEqual(summary[0], "Particles: 5")
+        self.assertTrue(summary[1].startswith("Reference file used:"))
+
     def _runTomoSubtomogramInitialModelWithSubtomo(self):
 
         protTomoExtraction = self._runPreviousProtocols()


### PR DESCRIPTION
Closes https://github.com/EyeSeeTea/scipion-em-eman2/issues/11

- Fix EmanProtTomoInitialModel.summary (and add test).
- Don't fail when EmanProtTomoInitialModel.reference is not set.