### PR TITLE
Proper implementation of parallelization

### DIFF
--- a/eman2/convert/convert.py
+++ b/eman2/convert/convert.py
@@ -566,10 +566,10 @@ def updateSetOfSubTomograms(inputSetOfSubTomograms, outputSetOfSubTomograms, par
         setattr(subTomogram, 'score', Float(particleParams["score"]))
         # Create 4x4 matrix from 4x3 e2spt_sgd align matrix and append row [0,0,0,1]
         am = particleParams["alignMatrix"]
-        angles = numpy.ndarray([am[0:3], am[4:7], am[8:11], [0, 0, 0]])
+        angles = numpy.array([am[0:3], am[4:7], am[8:11], [0, 0, 0]])
         samplingRate = outputSetOfSubTomograms.getSamplingRate()
-        shift = numpy.ndarray([am[3] * samplingRate, am[7] * samplingRate, am[11] * samplingRate, 1])
-        matrix = numpy.concatenate((angles, shift.T), axis=1)
+        shift = numpy.array([am[3] * samplingRate, am[7] * samplingRate, am[11] * samplingRate, 1])
+        matrix = numpy.column_stack((angles, shift.T))
         subTomogram.setTransform(Transform(matrix))
 
     outputSetOfSubTomograms.copyItems(inputSetOfSubTomograms,

--- a/eman2/protocols/protocol_tomo_extraction.py
+++ b/eman2/protocols/protocol_tomo_extraction.py
@@ -36,6 +36,8 @@ from tomo.objects import SetOfSubTomograms, SubTomogram, TomoAcquisition
 import eman2
 from eman2.constants import *
 
+from .. import SCRATCHDIR
+
 # Tomogram type constants for particle extraction
 SAME_AS_PICKING = 0
 OTHER = 1
@@ -149,8 +151,14 @@ class EmanProtTomoExtraction(EMProtocol, ProtTomoBase):
             self.cshrink = float(samplingRateCoord / samplingRateTomo)
             if self.cshrink > 1:
                 args += ' --cshrink %d' % self.cshrink
+            if self.numberOfMpi > 1:
+                args += ' --parallel=mpi:%(mpis)d:%(scratch)s' % self.numberOfMpi.get(), SCRATCHDIR
+            else:
+                args += ' --parallel=thread:%(threads)d' % self.numberOfThreads.get()
+            args += ' --threads=%(threads)d' % self.numberOfThreads.get()
             program = eman2.Plugin.getProgram('e2spt_boxer_old.py')
-            self.runJob(program, args, cwd=self._getExtraPath())
+            self.runJob(program, args, cwd=self._getExtraPath(),
+                        numberOfMpi=1, numberOfThreads=1)
             moveFile(self._getExtraPath(os.path.join('sptboxer_01', 'basename.hdf')),
                      self._getExtraPath(pwutils.replaceBaseExt(tomo, 'hdf')))
             cleanPath(self._getExtraPath("sptboxer_01"))

--- a/eman2/protocols/protocol_tomo_extraction.py
+++ b/eman2/protocols/protocol_tomo_extraction.py
@@ -36,8 +36,6 @@ from tomo.objects import SetOfSubTomograms, SubTomogram, TomoAcquisition
 import eman2
 from eman2.constants import *
 
-from .. import SCRATCHDIR
-
 # Tomogram type constants for particle extraction
 SAME_AS_PICKING = 0
 OTHER = 1
@@ -106,7 +104,8 @@ class EmanProtTomoExtraction(EMProtocol, ProtTomoBase):
                       help='Use normalize.edgemean if the particles have a clear solvent background '
                            '(i.e., they are not part of a larger complex or embeded in a membrane)')
 
-        form.addParallelSection(threads=4, mpi=1)
+        # Uncomment once migrated to new tomo extraction (e2spt_extract.py)
+        # form.addParallelSection(threads=4, mpi=0)
 
     # --------------------------- INSERT steps functions ----------------------
 
@@ -151,11 +150,9 @@ class EmanProtTomoExtraction(EMProtocol, ProtTomoBase):
             self.cshrink = float(samplingRateCoord / samplingRateTomo)
             if self.cshrink > 1:
                 args += ' --cshrink %d' % self.cshrink
-            if self.numberOfMpi > 1:
-                args += ' --parallel=mpi:%(mpis)d:%(scratch)s' % self.numberOfMpi.get(), SCRATCHDIR
-            else:
-                args += ' --parallel=thread:%(threads)d' % self.numberOfThreads.get()
-            args += ' --threads=%(threads)d' % self.numberOfThreads.get()
+
+            # Uncomment once migrated to new tomo extraction (e2spt_extract.py)
+            # args += ' --threads=% d' % self.numberOfThreads.get()
             program = eman2.Plugin.getProgram('e2spt_boxer_old.py')
             self.runJob(program, args, cwd=self._getExtraPath(),
                         numberOfMpi=1, numberOfThreads=1)

--- a/eman2/protocols/protocol_tomo_reconstruction.py
+++ b/eman2/protocols/protocol_tomo_reconstruction.py
@@ -181,8 +181,7 @@ class EmanProtTomoReconstruction(EMProtocol, ProtTomoBase):
             'pkkeep': self.pkkeep.get(),
             'filterto': self.filterto.get(),
             'rmbeadthr': self.rmbeadthr.get(),
-            'threads': self.numberOfThreads.get(),
-            'mpis': self.numberOfMpi.get(),
+            'threads': self.numberOfThreads.get()
         }
 
         args = " ".join(self._getInputPaths())

--- a/eman2/protocols/protocol_tomo_reconstruction.py
+++ b/eman2/protocols/protocol_tomo_reconstruction.py
@@ -184,7 +184,6 @@ class EmanProtTomoReconstruction(EMProtocol, ProtTomoBase):
             'clipz': self.clipz.get(),
             'pk_mindist': self.pkMindist.get(),
             'pkkeep': self.pkkeep.get(),
-            'threads': self.threads.get(),
             'filterto': self.filterto.get(),
             'rmbeadthr': self.rmbeadthr.get(),
             'threads': self.numberOfThreads.get(),

--- a/eman2/protocols/protocol_tomo_subtomogram_refinement.py
+++ b/eman2/protocols/protocol_tomo_subtomogram_refinement.py
@@ -162,10 +162,10 @@ class EmanProtTomoRefinement(EMProtocol, ProtTomoBase):
         if self.localfilter:
             args += ' --localfilter '
         if self.numberOfMpi > 1:
-            args += ' --parallel=mpi:%(mpis)d:%(scratch)s' % self.numberOfMpi.get(), SCRATCHDIR
+            args += ' --parallel=mpi:%d:%s' % (self.numberOfMpi.get(), SCRATCHDIR)
         else:
-            args += ' --parallel=thread:%(threads)d' % self.numberOfThreads.get()
-        args += ' --threads=%(threads)d' % self.numberOfThreads.get()
+            args += ' --parallel=thread:%d' % self.numberOfThreads.get()
+        args += ' --threads=%d' % self.numberOfThreads.get()
 
         program = eman2.Plugin.getProgram('e2spt_refine.py')
         self._log.info('Launching: ' + program + ' ' + args)

--- a/eman2/protocols/protocol_tomo_subtomogram_refinement.py
+++ b/eman2/protocols/protocol_tomo_subtomogram_refinement.py
@@ -66,7 +66,6 @@ class EmanProtTomoRefinement(EMProtocol, ProtTomoBase):
 
     def __init__(self, **kwargs):
         EMProtocol.__init__(self, **kwargs)
-        self.stepsExecutionMode = STEPS_PARALLEL
 
     # --------------- DEFINE param functions ---------------
 
@@ -123,7 +122,7 @@ class EmanProtTomoRefinement(EMProtocol, ProtTomoBase):
                            'Assumes tilt axis exactly on Y and zero tilt in X-Y'
                            'plane. Default 90 (no limit).')
 
-        form.addParallelSection(threads=2, mpi=4)
+        form.addParallelSection(threads=4, mpi=1)
 
     # --------------- INSERT steps functions ----------------
 

--- a/eman2/protocols/protocol_tomo_subtomogram_refinement.py
+++ b/eman2/protocols/protocol_tomo_subtomogram_refinement.py
@@ -89,9 +89,6 @@ class EmanProtTomoRefinement(EMProtocol, ProtTomoBase):
         form.addParam('mass', params.FloatParam, default=500.0,
                       label='Mass:',
                       help='Default=500.0')
-        form.addParam('threads', params.IntParam, default=2,
-                      label='Threads:',
-                      help='Number of threads')
         form.addParam('pkeep', params.FloatParam, default=0.8,
                       label='Particle keep:',
                       help='Fraction of particles to keep')
@@ -153,7 +150,6 @@ class EmanProtTomoRefinement(EMProtocol, ProtTomoBase):
         if self.inputRef.get() is not None:
             args += (' --reference=%s ' % self.inputRef.get().getFileName())
         args += (' --mass=%f' % self.mass)
-        args += ' --threads=%d' % self.threads
         args += ' --goldstandard=%d ' % self.goldstandard
         args += ' --pkeep=%f ' % self.pkeep
         args += ' --sym=%s ' % self.sym

--- a/eman2/protocols/protocol_tomo_subtomogram_refinement.py
+++ b/eman2/protocols/protocol_tomo_subtomogram_refinement.py
@@ -41,6 +41,8 @@ import eman2
 from tomo.protocols import ProtTomoBase
 from tomo.objects import AverageSubTomogram, SetOfSubTomograms, SetOfAverageSubTomograms
 
+from .. import SCRATCHDIR
+
 SAME_AS_PICKING = 0
 
 
@@ -163,10 +165,16 @@ class EmanProtTomoRefinement(EMProtocol, ProtTomoBase):
             args += ' --goldcontinue '
         if self.localfilter:
             args += ' --localfilter '
+        if self.numberOfMpi > 1:
+            args += ' --parallel=mpi:%(mpis)d:%(scratch)s' % self.numberOfMpi.get(), SCRATCHDIR
+        else:
+            args += ' --parallel=thread:%(threads)d' % self.numberOfThreads.get()
+        args += ' --threads=%(threads)d' % self.numberOfThreads.get()
 
         program = eman2.Plugin.getProgram('e2spt_refine.py')
         self._log.info('Launching: ' + program + ' ' + args)
-        self.runJob(program, args)
+        self.runJob(program, args,
+                    numberOfMpi=1, numberOfThreads=1)
 
     def getLastFromOutputPath(self, pattern):
         threedPaths = glob(self.getOutputPath("*"))

--- a/eman2/protocols/protocol_tomo_template_match.py
+++ b/eman2/protocols/protocol_tomo_template_match.py
@@ -85,8 +85,6 @@ class EmanProtTomoTempMatch(ProtTomoPicking):
         form.addParam('boxSize', FloatParam, important=True, label='Box size',
                       help="The wizard selects same box size as reference size")
 
-        form.addParallelSection(threads=4, mpi=0)
-
     # --------------------------- INSERT steps functions ----------------------
 
     def _insertAllSteps(self):
@@ -134,7 +132,6 @@ class EmanProtTomoTempMatch(ProtTomoPicking):
         params = params + " --reference=%s --nptcl=%d --dthr=%f --vthr=%f --delta=%f --sym=%s " \
                           "--rmedge --rmgold --boxsz=%d" % (volFile, self.nptcl.get(), self.dthr.get(),
                                                             self.vthr.get(), self.delta.get(), self.sym.get(), self.box)
-        params += ' --threads=%d' % self.numberOfThreads.get()
 
         program = eman2.Plugin.getProgram("e2spt_tempmatch.py")
 

--- a/eman2/protocols/protocol_tomo_template_match.py
+++ b/eman2/protocols/protocol_tomo_template_match.py
@@ -134,7 +134,7 @@ class EmanProtTomoTempMatch(ProtTomoPicking):
         params = params + " --reference=%s --nptcl=%d --dthr=%f --vthr=%f --delta=%f --sym=%s " \
                           "--rmedge --rmgold --boxsz=%d" % (volFile, self.nptcl.get(), self.dthr.get(),
                                                             self.vthr.get(), self.delta.get(), self.sym.get(), self.box)
-        params += ' --threads=%(threads)d' % self.numberOfThreads.get()
+        params += ' --threads=%d' % self.numberOfThreads.get()
 
         program = eman2.Plugin.getProgram("e2spt_tempmatch.py")
 

--- a/eman2/protocols/protocol_tomo_template_match.py
+++ b/eman2/protocols/protocol_tomo_template_match.py
@@ -39,6 +39,8 @@ from eman2.convert import loadJson, readSetOfCoordinates3D
 from tomo.protocols import ProtTomoPicking
 from tomo.objects import SetOfCoordinates3D
 
+from .. import SCRATCHDIR
+
 
 class EmanProtTomoTempMatch(ProtTomoPicking):
     """
@@ -134,11 +136,17 @@ class EmanProtTomoTempMatch(ProtTomoPicking):
         params = params + " --reference=%s --nptcl=%d --dthr=%f --vthr=%f --delta=%f --sym=%s " \
                           "--rmedge --rmgold --boxsz=%d" % (volFile, self.nptcl.get(), self.dthr.get(),
                                                             self.vthr.get(), self.delta.get(), self.sym.get(), self.box)
+        if self.numberOfMpi > 1:
+            params += ' --parallel=mpi:%(mpis)d:%(scratch)s' % self.numberOfMpi.get(), SCRATCHDIR
+        else:
+            params += ' --parallel=thread:%(threads)d' % self.numberOfThreads.get()
+        params += ' --threads=%(threads)d' % self.numberOfThreads.get()
 
         program = eman2.Plugin.getProgram("e2spt_tempmatch.py")
 
         self.runJob(program, params, cwd=os.path.abspath(self._getTmpPath()),
-                    env=eman2.Plugin.getEnviron())
+                    env=eman2.Plugin.getEnviron(),
+                    numberOfMpi=1, numberOfThreads=1)
 
         # Move output files to Extra Path
         moveFile(self._getTmpPath("ccc.hdf"), self._getExtraPath("particles" + ".hdf"))

--- a/eman2/protocols/protocol_tomo_template_match.py
+++ b/eman2/protocols/protocol_tomo_template_match.py
@@ -39,8 +39,6 @@ from eman2.convert import loadJson, readSetOfCoordinates3D
 from tomo.protocols import ProtTomoPicking
 from tomo.objects import SetOfCoordinates3D
 
-from .. import SCRATCHDIR
-
 
 class EmanProtTomoTempMatch(ProtTomoPicking):
     """
@@ -87,7 +85,7 @@ class EmanProtTomoTempMatch(ProtTomoPicking):
         form.addParam('boxSize', FloatParam, important=True, label='Box size',
                       help="The wizard selects same box size as reference size")
 
-        form.addParallelSection(threads=1, mpi=1)
+        form.addParallelSection(threads=4, mpi=0)
 
     # --------------------------- INSERT steps functions ----------------------
 
@@ -136,10 +134,6 @@ class EmanProtTomoTempMatch(ProtTomoPicking):
         params = params + " --reference=%s --nptcl=%d --dthr=%f --vthr=%f --delta=%f --sym=%s " \
                           "--rmedge --rmgold --boxsz=%d" % (volFile, self.nptcl.get(), self.dthr.get(),
                                                             self.vthr.get(), self.delta.get(), self.sym.get(), self.box)
-        if self.numberOfMpi > 1:
-            params += ' --parallel=mpi:%(mpis)d:%(scratch)s' % self.numberOfMpi.get(), SCRATCHDIR
-        else:
-            params += ' --parallel=thread:%(threads)d' % self.numberOfThreads.get()
         params += ' --threads=%(threads)d' % self.numberOfThreads.get()
 
         program = eman2.Plugin.getProgram("e2spt_tempmatch.py")


### PR DESCRIPTION
Fix #67
Fix #68 

- No parallelization for tomo boxer
- No parallelization for initial model. It looks like they are using the batchsize somehow as the thread parameter (See https://blake.bcm.edu/emanwiki/EMAN2/e2TomoSmall look for 'batchsize' and https://github.com/cryoem/eman2/blob/master/programs/e2spt_sgd.py#L137). 
- No parallelization for extract particles. We are using an old version of the extract particles (e2spt_boxer_old). We can add support for parallelization once we migrate to the new version (e2spt_extract) => See https://github.com/scipion-em/scipion-em-eman2/issues/71
- Parallelization for reconstruct (just threads) and subtomo ref (threads and mpi)
- No parallelization for template matching. Threads support was added (https://github.com/cryoem/eman2/commit/4530131ddab39954697599e5e37c75ea855d68bb#diff-3646198d027310a263c3de326d641a8b) after releasing 2.31 (https://github.com/cryoem/eman2/releases/tag/v2.31)
