### PR TITLE
Disable Template Matching

### DIFF
--- a/eman2/protocols/protocol_tomo_template_match.py
+++ b/eman2/protocols/protocol_tomo_template_match.py
@@ -59,7 +59,6 @@ class EmanProtTomoTempMatch(ProtTomoPicking):
     def isDisabled(cls):
         """ Return True if this Protocol is disabled.
         Disabled protocols will not be offered in the available protocols."""
-        eman2.Plugin._defineVariables()
         if eman2.Plugin.getActiveVersion(versions=[eman2.V2_31]):
             return True
         else:

--- a/eman2/protocols/protocol_tomo_template_match.py
+++ b/eman2/protocols/protocol_tomo_template_match.py
@@ -55,6 +55,16 @@ class EmanProtTomoTempMatch(ProtTomoPicking):
     def __init__(self, **args):
         ProtTomoPicking.__init__(self, **args)
 
+    @classmethod
+    def isDisabled(cls):
+        """ Return True if this Protocol is disabled.
+        Disabled protocols will not be offered in the available protocols."""
+        eman2.Plugin._defineVariables()
+        if eman2.Plugin.getActiveVersion(versions=[eman2.V2_31]):
+            return True
+        else:
+            return False
+
     # --------------------------- DEFINE param functions ----------------------
 
     def _defineParams(self, form):

--- a/eman2/tests/test_protocols_eman.py
+++ b/eman2/tests/test_protocols_eman.py
@@ -839,6 +839,9 @@ class TestEmanTomoTempMatch(TestEmanTomoBase):
         TestEmanTomoBase.setData()
 
     def _runTomoTempMatch(self):
+        if EmanProtTomoTempMatch.isDisabled():
+            print("Test Cancelled. Template Matching is not supported in Eman 2.31")
+            return
         protImportTomogramBig = self.newProtocol(tomo.protocols.ProtImportTomograms,
                                                  filesPath=self.tomogram,
                                                  samplingRate=5)


### PR DESCRIPTION
Modifications added to `EmanProtTomoTempMatch` and `TestEmanTomoTempMatch` to disable them when the binaries installed belogn to the version 2.31