### PR TITLE
Default EMAN_HOME 2.31.

### DIFF
--- a/eman2/__init__.py
+++ b/eman2/__init__.py
@@ -47,7 +47,7 @@ class Plugin(pwem.Plugin):
 
     @classmethod
     def _defineVariables(cls):
-        cls._defineEmVar(EMAN2_HOME, 'eman-' + cls.getActiveVersion())
+        cls._defineEmVar(EMAN2_HOME, 'eman-' + V2_31)
 
     @classmethod
     def getEnviron(cls):


### PR DESCRIPTION
Validate was failing in case you fo not have EMAN_HOME define in the config. it was calling getActiveVersion, which needs EMAN_HOME.