### PR TITLE
Eman Tomo Fixes

### DIFF
--- a/eman2/convert/convert.py
+++ b/eman2/convert/convert.py
@@ -578,16 +578,16 @@ def updateSetOfSubTomograms(inputSetOfSubTomograms, outputSetOfSubTomograms, par
 
 
 def setCoords3D2Jsons(setTomograms, setCoords, path):
-    for tomo in setTomograms.iterItems():
+    for tomo in setTomograms.getFiles():
         coords = []
         for coor in setCoords.iterCoordinates():
-            if pwutils.removeBaseExt(tomo.getFileName()) == pwutils.removeBaseExt(coor.getVolName()):
+            if pwutils.removeBaseExt(tomo) == pwutils.removeBaseExt(coor.getVolName()):
                 coords.append([coor.getX(), coor.getY(), coor.getZ(), "manual", 0.0, 0])
 
         coordDict = {"boxes_3d": coords,
                      "class_list": {"0": {"boxsize": setCoords.getBoxSize(), "name": "particles_00"}}
                      }
-        tomoBasename = pwutils.removeBaseExt(tomo.getFileName())
+        tomoBasename = pwutils.removeBaseExt(tomo)
         if "__" in tomoBasename:
             fnInputCoor = '%s_info.json' % tomoBasename.split("__")[0]
         else:

--- a/eman2/convert/convert.py
+++ b/eman2/convert/convert.py
@@ -199,7 +199,7 @@ def writeSetOfSubTomograms(subtomogramSet, path, **kwargs):
         firstCoord = subtomogramSet.getFirstItem().getCoordinate3D() or None
         hasVolName = False
         if firstCoord:
-            hasVolName = firstCoord.getVolName() or False
+            hasVolName = subtomogramSet.getFirstItem().getVolName() or False
 
         fileName = ""
         a = 0
@@ -208,7 +208,7 @@ def writeSetOfSubTomograms(subtomogramSet, path, **kwargs):
         for i, subtomo in iterSubtomogramsByVol(subtomogramSet):
             volName = volId = subtomo.getVolId()
             if hasVolName:
-                volName = pwutils.removeBaseExt(subtomo.getCoordinate3D().getVolName())
+                volName = pwutils.removeBaseExt(subtomogramSet.getFirstItem().getVolName())
             objDict = subtomo.getObjDict()
 
             if not volId:

--- a/eman2/protocols/protocol_tomo_extraction.py
+++ b/eman2/protocols/protocol_tomo_extraction.py
@@ -225,14 +225,18 @@ class EmanProtTomoExtraction(EMProtocol, ProtTomoBase):
 
     def _summary(self):
         summary = []
-        summary.append("Tomogram source: %s"
+        summary.append("Tomogram source: *%s*"
                        % self.getEnumText("tomoSource"))
         if self.getOutputsSize() >= 1:
-            summary.append("Particle box size: %s" % self.boxSize.get())
-            summary.append("Subtomogram extracted: %s" %
+            summary.append("Particle box size: *%s*" % self.boxSize.get())
+            summary.append("Subtomogram extracted: *%s*" %
                            self.inputCoordinates.get().getSize())
         else:
             summary.append("Output subtomograms not ready yet.")
+        if self.doInvert:
+            summary.append('*White over black.*')
+        else:
+            summary.append('*Black over white.*')
         return summary
 
     # --------------------------- UTILS functions ----------------------------------

--- a/eman2/protocols/protocol_tomo_extraction.py
+++ b/eman2/protocols/protocol_tomo_extraction.py
@@ -136,7 +136,9 @@ class EmanProtTomoExtraction(EMProtocol, ProtTomoBase):
                 for coord3D in coords.iterCoordinates(volume=tomo):
                     if os.path.basename(tomo.getFileName()) == os.path.basename(coord3D.getVolName()):
                         out.write("%d\t%d\t%d\n" % (coord3D.getX(), coord3D.getY(), coord3D.getZ()))
-                        coordDict.append(coord3D.clone())
+                        newCoord = coord3D.clone()
+                        newCoord.setVolume(coord3D.getVolume())
+                        coordDict.append(newCoord)
 
             if coordDict:
                 self.lines.append(coordDict)
@@ -147,7 +149,7 @@ class EmanProtTomoExtraction(EMProtocol, ProtTomoBase):
         samplingRateCoord = self.inputCoordinates.get().getSamplingRate()
         samplingRateTomo = self.getInputTomograms().getFirstItem().getSamplingRate()
         for tomo in self.tomoFiles:
-            args = '%s ' % tomo
+            args = '%s ' % os.path.abspath(tomo)
             args += "--coords % s --boxsize % d" % (pwutils.replaceBaseExt(tomo, 'coords'), self.boxSize.get())
             if self.doInvert:
                 args += ' --invert'
@@ -255,10 +257,11 @@ class EmanProtTomoExtraction(EMProtocol, ProtTomoBase):
             dfactor = self.downFactor.get()
             if dfactor != 1:
                 fnSubtomo = self._getExtraPath("downsampled_subtomo%d.mrc" % counter)
-                ImageHandler.scaleSplines(subtomogram.getLocation(), fnSubtomo, dfactor)
+                ImageHandler.scaleSplines(subtomogram.getLocation()[1]+':mrc', fnSubtomo, dfactor)
                 subtomogram.setVolId(volId)
                 subtomogram.setLocation(fnSubtomo)
             subtomogram.setCoordinate3D(coordSet[counter])
+            subtomogram.setTransform(coordSet[counter]._eulerMatrix)
             subtomogram.setVolName(tomoFile)
             outputSubTomogramsSet.append(subtomogram)
         return outputSubTomogramsSet

--- a/eman2/viewers/views_tkinter_tree.py
+++ b/eman2/viewers/views_tkinter_tree.py
@@ -74,7 +74,7 @@ class EmanDialog(ToolbarListDialog):
         self._moveCoordsToInfo(tomo)
 
         program = eman2.Plugin.getProgram("e2spt_boxer.py")
-        arguments = "%s" % tomo.getFileName()
+        arguments = "%s" % os.path.abspath(tomo.getFileName())
         if inMemory:
             arguments += " --inmemory"
         runJob(None, program, arguments, env=eman2.Plugin.getEnviron(), cwd=self.path)


### PR DESCRIPTION
Several corrections have been added to fix the errors that were appearing on the tests (with the exception of subtomogram refinement).

Viewer of Coordinates3D objects based on Eman picking has been fixed.

Improvements were also added to protocol_tomo_extraction (Transformation matrices are now copied to the output Subtomograms, leaving the identity if the input coordinates didn't have such information).