### PR TITLE
Dh temp match fix

### DIFF
--- a/eman2/__init__.py
+++ b/eman2/__init__.py
@@ -167,6 +167,6 @@ class Plugin(pwem.Plugin):
                        commands=eman231_commands,
                        default=True)
 
-        env.addPackage('eman', version=V3_0_0,
-                       commands=eman3_commands,
-                       tar=VOID_TGZ)
+        # env.addPackage('eman', version=V3_0_0,
+        #                commands=eman3_commands,
+        #                tar=VOID_TGZ)

--- a/eman2/protocols/protocol_tomo_initialmodel.py
+++ b/eman2/protocols/protocol_tomo_initialmodel.py
@@ -77,11 +77,6 @@ class EmanProtTomoInitialModel(EMProtocol, ProtTomoBase):
                            'h(n), tet, oct, icos.\n'
                            'See http://blake.bcm.edu/emanwiki/EMAN2/Symmetry\n'
                            'for a detailed description of symmetry in Eman.')
-
-        form.addParam('gaussFilter', params.FloatParam, default=-1,
-                      expertLevel=params.LEVEL_ADVANCED,
-                      label='Gauss',
-                      help='The Gaussian filter level')
         form.addParam('filterto', params.FloatParam, default=0.02,
                       expertLevel=params.LEVEL_ADVANCED,
                       label='Filterto',
@@ -133,7 +128,6 @@ class EmanProtTomoInitialModel(EMProtocol, ProtTomoBase):
     def createInitialModelStep(self):
         command_params = {
             'symmetry': self.symmetry.get(),
-            'gaussFilter': self.gaussFilter.get(),
             'filterto': self.filterto.get(),
             'batchSize': self.batchSize.get(),
             'learningRate': self.learningRate.get(),
@@ -144,11 +138,12 @@ class EmanProtTomoInitialModel(EMProtocol, ProtTomoBase):
             'reference': self.reference.get().getFileName() if self.reference.get() else None,
             'outputPath': self.getOutputPath(),
         }
+
         args = '%s/*.hdf' % self._getExtraPath("particles")
         if command_params['reference']:
             args += ' --reference=%(reference)s'
 
-        args += (' --sym=%(symmetry)s --gaussz=%(gaussFilter)f --filterto=%(filterto)f'
+        args += (' --sym=%(symmetry)s --filterto=%(filterto)f'
                  ' --batchsize=%(batchSize)d --learnrate=%(learningRate)f --niter=%(numberOfIterations)d'
                  ' --nbatch=%(numberOfBatches)d')
 

--- a/eman2/tests/test_protocols_eman.py
+++ b/eman2/tests/test_protocols_eman.py
@@ -841,9 +841,6 @@ class TestEmanTomoTempMatch(TestEmanTomoBase):
         TestEmanTomoBase.setData()
 
     def _runTomoTempMatch(self):
-        if EmanProtTomoTempMatch.isDisabled():
-            print("Test Cancelled. Template Matching is not supported in Eman 2.31")
-            return
         protImportTomogramBig = self.newProtocol(tomo.protocols.ProtImportTomograms,
                                                  filesPath=self.tomogram,
                                                  samplingRate=5)
@@ -886,6 +883,9 @@ class TestEmanTomoTempMatch(TestEmanTomoBase):
         return protTomoTempMatchBig, protTomoTempMatchSmall
 
     def test_TempMatch(self):
+        if EmanProtTomoTempMatch.isDisabled():
+            print("Test Cancelled. Template Matching is not supported in Eman 2.31")
+            return
         protTomoTempMatch = self._runTomoTempMatch()
 
         outputCoordsBig = protTomoTempMatch[0].output3DCoordinates

--- a/eman2/tests/test_protocols_eman.py
+++ b/eman2/tests/test_protocols_eman.py
@@ -892,7 +892,7 @@ class TestEmanTomoTempMatch(TestEmanTomoBase):
         if eman2.Plugin.isVersion(eman2.V2_3):
             self.assertEqual(outputCoordsBig.getSize(), 19)
         elif eman2.Plugin.isVersion(eman2.V3_0_0):
-            self.assertEqual(outputCoordsBig.getSize(), 17)
+            self.assertAlmostEqual(outputCoordsBig.getSize(), 17, delta=1)
         self.assertEqual(outputCoordsBig.getBoxSize(), 128)
         self.assertEqual(outputCoordsBig.getSamplingRate(), 5)
 
@@ -900,7 +900,7 @@ class TestEmanTomoTempMatch(TestEmanTomoBase):
         if eman2.Plugin.isVersion(eman2.V2_3):
             self.assertEqual(outputCoordsSmall.getSize(), 2)
         elif eman2.Plugin.isVersion(eman2.V3_0_0):
-            self.assertEqual(outputCoordsSmall.getSize(), 45)
+            self.assertAlmostEqual(outputCoordsSmall.getSize(), 45, delta=1)
         self.assertEqual(outputCoordsSmall.getBoxSize(), 128)
         self.assertEqual(outputCoordsSmall.getSamplingRate(), 5)
 


### PR DESCRIPTION
This fixes:
TomoInitialModel should work for 2.31
Tomo Template matching test should not fail if 2.31 (but is skipped)
Plugin does not work fine with eman-3.0.0-alpha (needs some work when e2convert,py is needed): binary commented.