### PR TITLE
Fixes for subtomogram refinement

### DIFF
--- a/eman2/convert/convert.py
+++ b/eman2/convert/convert.py
@@ -336,7 +336,7 @@ def writeSetOfParticles(partSet, path, **kwargs):
             # the index in EMAN begins with 0
             if fileName != objDict['_filename']:
                 fileName = objDict['_filename']
-                if objDict['_index'] == 0:
+                if objDict['_index'] == 0:  # TODO: Index appears to be the problem (when not given it works ok)
                     a = 0
                 else:
                     a = 1
@@ -469,7 +469,7 @@ def iterParticlesByMic(partSet):
 
 def iterSubtomogramsByVol(subtomogramSet):
     """ Iterate subtomograms ordered by tomogram """
-    items = list(subtomogramSet.iterItems(orderBy=['_volId', 'id'], direction='ASC'))
+    items = [subtomo.clone() for subtomo in subtomogramSet.iterItems(orderBy=['_volId', 'id'], direction='ASC')]
     for i, part in enumerate(items):
         yield i, part
 

--- a/eman2/protocols/protocol_tomo_extraction.py
+++ b/eman2/protocols/protocol_tomo_extraction.py
@@ -259,11 +259,8 @@ class EmanProtTomoExtraction(EMProtocol, ProtTomoBase):
         for counter, subtomoFile in enumerate(subtomoFileList):
             subtomogram = SubTomogram()
             subtomogram.cleanObjId()
-            # subtomogram.setLocation(counter, subtomoFile)
+            subtomogram.setLocation(subtomoFile)
             dfactor = self.downFactor.get()
-            convertFile = self._getExtraPath('convert_' + pwutils.removeBaseExt(subtomoFile) + '.mrc')
-            ih.convert(subtomoFile + ':mrc', convertFile)
-            subtomogram.setLocation(convertFile)
             if dfactor != 1:
                 fnSubtomo = self._getExtraPath("downsampled_subtomo%d.mrc" % counter)
                 ImageHandler.scaleSplines(subtomogram.getLocation()[1]+':mrc', fnSubtomo, dfactor)

--- a/eman2/protocols/protocol_tomo_extraction.py
+++ b/eman2/protocols/protocol_tomo_extraction.py
@@ -191,7 +191,7 @@ class EmanProtTomoExtraction(EMProtocol, ProtTomoBase):
             for ind, tomoFile in enumerate(self.tomoFiles):
                 if os.path.basename(tomoFile) == os.path.basename(item.getFileName()):
                     coordSet = self.lines[ind]
-                    outputSet = self.readSetOfSubTomograms(self._getExtraPath(os.path.basename(tomoFile)),
+                    outputSet = self.readSetOfSubTomograms(tomoFile,
                                                            self.outputSubTomogramsSet,
                                                            coordSet,
                                                            item.getObjId())
@@ -253,12 +253,17 @@ class EmanProtTomoExtraction(EMProtocol, ProtTomoBase):
             return self.inputTomograms.get()
 
     def readSetOfSubTomograms(self, tomoFile, outputSubTomogramsSet, coordSet, volId):
-        subtomoFileList = sorted(glob.glob(pwutils.removeExt(tomoFile) + '*.mrc'))
+        outRegex = self._getExtraPath(pwutils.removeBaseExt(tomoFile) + '*.mrc')
+        subtomoFileList = sorted(glob.glob(outRegex))
+        ih = ImageHandler()
         for counter, subtomoFile in enumerate(subtomoFileList):
             subtomogram = SubTomogram()
             subtomogram.cleanObjId()
-            subtomogram.setLocation(counter, subtomoFile)
+            # subtomogram.setLocation(counter, subtomoFile)
             dfactor = self.downFactor.get()
+            convertFile = self._getExtraPath('convert_' + pwutils.removeBaseExt(subtomoFile) + '.mrc')
+            ih.convert(subtomoFile + ':mrc', convertFile)
+            subtomogram.setLocation(convertFile)
             if dfactor != 1:
                 fnSubtomo = self._getExtraPath("downsampled_subtomo%d.mrc" % counter)
                 ImageHandler.scaleSplines(subtomogram.getLocation()[1]+':mrc', fnSubtomo, dfactor)

--- a/eman2/protocols/protocol_tomo_subtomogram_refinement.py
+++ b/eman2/protocols/protocol_tomo_subtomogram_refinement.py
@@ -137,11 +137,8 @@ class EmanProtTomoRefinement(EMProtocol, ProtTomoBase):
     def convertInputStep(self):
         storePath = self._getExtraPath("subtomograms")
         pwutils.makePath(storePath)
-
-        fns = list(self.inputSetOfSubTomogram.get().getFiles())[0]
-        self.newFn = pwutils.removeBaseExt(fns).split('__ctf')[0] + '.hdf'
-        self.newFn = pwutils.join(storePath, self.newFn)
         writeSetOfSubTomograms(self.inputSetOfSubTomogram.get(), storePath)
+        self.newFn = glob(os.path.join(storePath, '*.hdf'))[0]
 
     def refinementSubtomogram(self):
         """ Run the Subtomogram refinement. """


### PR DESCRIPTION
Some modifications have been added to fix subtomogram refinement with Eman:

- Index is no longer specified when setting the location of the output subtomograms after an extraction. A minor fix has also been included to correct the path used to associate each subtomogram with its corresponding tomogram in the sqlite.

- Conversion step in the subtomogram refinement protocol now assignes correctly the path to the `.hdf` file generated during this step.